### PR TITLE
IS-639 Successful Habits Post Activity clean up

### DIFF
--- a/assets/content.js
+++ b/assets/content.js
@@ -4,8 +4,7 @@ export const content = {
     description:
       'Choose one healthy habit you have sustained long-term. Reflect on why you think you’ve been able to stick with it for so long. This will give you information you can use to help you build and maintain new habits.',
     timeEst: 8,
-    type: '$Reflection Activity',
-    // image: require('./suc-hag-img.png'),
+    type: 'Reflection Activity',
     prompts: [
       {
         contemplation:

--- a/assets/content.js
+++ b/assets/content.js
@@ -18,8 +18,7 @@ export const content = {
       }
     ],
     postActivity: [
-      'What insights from this reflection can you apply to your pursuit of this vision and goal?',
-      'Where will you apply what you just reflected on in your daily life?'
+      'What insights from this reflection can you apply to your pursuit of this vision and goal?'
     ]
   }
 }

--- a/src/screens/SucHab01Screens/PostActivity.js
+++ b/src/screens/SucHab01Screens/PostActivity.js
@@ -121,7 +121,9 @@ const PostActivity = ({ postActivity }) => {
             shadowColor: '#000000',
             shadowOpacity: 0.4,
             shadowRadius: 8,
-            shadowOffset: { height: 4 }
+            shadowOffset: { height: 4 },
+            marginBottom: 48,
+            minHeight: 320
           }}>
           <Text style={styles.importedText}>
             {postActivity.length > resCount
@@ -131,7 +133,8 @@ const PostActivity = ({ postActivity }) => {
           <TextInput
             style={{
               textAlignVertical: 'top',
-              minHeight: 150,
+              minHeight: 200,
+              // height: '80%',
               marginTop: 16
             }}
             onChangeText={(msg) => {

--- a/src/screens/SucHab01Screens/PostActivity.js
+++ b/src/screens/SucHab01Screens/PostActivity.js
@@ -181,7 +181,8 @@ const PostActivity = ({ postActivity }) => {
             onPress={() => navigation.navigate('Flows')}
             style={{
               ...styles.button,
-              backgroundColor: '#193340'
+              backgroundColor: '#193340',
+              opacity: postActivity.length > resCount ? 0.4 : null
             }}>
             <Text
               style={{

--- a/src/screens/SucHab01Screens/PostActivity.js
+++ b/src/screens/SucHab01Screens/PostActivity.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import {
   View,
   SafeAreaView,
@@ -17,7 +17,8 @@ const PostActivity = ({ postActivity }) => {
   const { onFocus, onBlur } = useKeyboard()
   const navigation = useNavigation()
   const [res, setRes] = useState('')
-  const [resCount, setResCount] = useState(0)
+  const [responses, setResponses] = useState([])
+  const [saveDisabled, setSaveDisabled] = useState(true)
 
   const styles = StyleSheet.create({
     container: {
@@ -55,6 +56,14 @@ const PostActivity = ({ postActivity }) => {
       justifyContent: 'center'
     }
   })
+
+  useEffect(() => {
+    if (res.length) {
+      setSaveDisabled(false)
+    } else {
+      setSaveDisabled(true)
+    }
+  }, [res])
 
   return (
     <SafeAreaView>
@@ -126,15 +135,14 @@ const PostActivity = ({ postActivity }) => {
             minHeight: 320
           }}>
           <Text style={styles.importedText}>
-            {postActivity.length > resCount
-              ? postActivity[resCount]
+            {postActivity.length > responses.length
+              ? postActivity[responses.length]
               : postActivity[postActivity.length - 1]}
           </Text>
           <TextInput
             style={{
               textAlignVertical: 'top',
               minHeight: 200,
-              // height: '80%',
               marginTop: 16
             }}
             onChangeText={(msg) => {
@@ -152,22 +160,36 @@ const PostActivity = ({ postActivity }) => {
               width: '100%',
               alignItems: 'flex-end'
             }}>
-            <Text
+            <TouchableOpacity
+              disabled={saveDisabled}
               style={{
-                color: '#00968A',
-                fontSize: 17,
-                fontStyle: 'normal',
-                fontWeight: '500',
-                lineHeight: 20,
-                letterSpacing: -0.01,
-                textAlign: 'right'
+                opacity:
+                  saveDisabled || postActivity.length === responses.length
+                    ? 0.4
+                    : null
               }}
               onPress={() => {
-                setResCount(resCount + 1)
-                setRes('')
+                if (postActivity.length > responses.length) {
+                  setResponses([...responses, res])
+                  setSaveDisabled(true)
+                  return
+                } else {
+                  setRes('')
+                }
               }}>
-              SAVE
-            </Text>
+              <Text
+                style={{
+                  color: '#00968A',
+                  fontSize: 17,
+                  fontStyle: 'normal',
+                  fontWeight: '500',
+                  lineHeight: 20,
+                  letterSpacing: -0.01,
+                  textAlign: 'right'
+                }}>
+                SAVE
+              </Text>
+            </TouchableOpacity>
           </View>
         </View>
         <View
@@ -177,12 +199,12 @@ const PostActivity = ({ postActivity }) => {
             alignItems: 'center'
           }}>
           <TouchableOpacity
-            disabled={postActivity.length > resCount}
+            disabled={postActivity.length > responses.length}
             onPress={() => navigation.navigate('Flows')}
             style={{
               ...styles.button,
               backgroundColor: '#193340',
-              opacity: postActivity.length > resCount ? 0.4 : null
+              opacity: postActivity.length > responses.length ? 0.4 : null
             }}>
             <Text
               style={{

--- a/src/screens/SucHab01Screens/PostActivity.js
+++ b/src/screens/SucHab01Screens/PostActivity.js
@@ -112,83 +112,85 @@ const PostActivity = ({ postActivity }) => {
             </Text>
           </View>
         </View>
-        {postActivity.length > resCount ? (
-          <View
+        <View
+          style={{
+            ...styles.container,
+            backgroundColor: '#fff',
+            borderWidth: 1,
+            borderColor: '#E5E5E5',
+            shadowColor: '#000000',
+            shadowOpacity: 0.4,
+            shadowRadius: 8,
+            shadowOffset: { height: 4 }
+          }}>
+          <Text style={styles.importedText}>
+            {postActivity.length > resCount
+              ? postActivity[resCount]
+              : postActivity[postActivity.length - 1]}
+          </Text>
+          <TextInput
             style={{
-              ...styles.container,
-              backgroundColor: '#fff',
-              borderWidth: 1,
-              borderColor: '#E5E5E5',
-              shadowColor: '#000000',
-              shadowOpacity: 0.4,
-              shadowRadius: 8,
-              shadowOffset: { height: 4 }
-            }}>
-            <Text style={styles.importedText}>{postActivity[resCount]}</Text>
-            <TextInput
-              style={{
-                textAlignVertical: 'top',
-                minHeight: 150,
-                marginTop: 16
-              }}
-              onChangeText={(msg) => {
-                setRes(msg)
-              }}
-              value={res}
-              placeholder={'Start typing...'}
-              multiline={true}
-              numberOfLines={14}
-              onBlur={onBlur}
-              onFocus={onFocus}
-            />
-            <View
-              style={{
-                width: '100%',
-                alignItems: 'flex-end'
-              }}>
-              <Text
-                style={{
-                  color: '#00968A',
-                  fontSize: 17,
-                  fontStyle: 'normal',
-                  fontWeight: '500',
-                  lineHeight: 20,
-                  letterSpacing: -0.01,
-                  textAlign: 'right'
-                }}
-                onPress={() => {
-                  setResCount(resCount + 1)
-                  setRes('')
-                }}>
-                SAVE
-              </Text>
-            </View>
-          </View>
-        ) : (
+              textAlignVertical: 'top',
+              minHeight: 150,
+              marginTop: 16
+            }}
+            onChangeText={(msg) => {
+              setRes(msg)
+            }}
+            value={res}
+            placeholder={'Start typing...'}
+            multiline={true}
+            numberOfLines={14}
+            onBlur={onBlur}
+            onFocus={onFocus}
+          />
           <View
             style={{
               width: '100%',
-              flexDirection: 'column',
-              alignItems: 'center'
+              alignItems: 'flex-end'
             }}>
-            <TouchableOpacity
-              onPress={() => navigation.navigate('Flows')}
+            <Text
               style={{
-                ...styles.button,
-                backgroundColor: '#193340'
+                color: '#00968A',
+                fontSize: 17,
+                fontStyle: 'normal',
+                fontWeight: '500',
+                lineHeight: 20,
+                letterSpacing: -0.01,
+                textAlign: 'right'
+              }}
+              onPress={() => {
+                setResCount(resCount + 1)
+                setRes('')
               }}>
-              <Text
-                style={{
-                  fontSize: 17,
-                  fontWeight: '500',
-                  textAlign: 'center',
-                  color: '#fff'
-                }}>
-                Finish Activity
-              </Text>
-            </TouchableOpacity>
+              SAVE
+            </Text>
           </View>
-        )}
+        </View>
+        <View
+          style={{
+            width: '100%',
+            flexDirection: 'column',
+            alignItems: 'center'
+          }}>
+          <TouchableOpacity
+            disabled={postActivity.length > resCount}
+            onPress={() => navigation.navigate('Flows')}
+            style={{
+              ...styles.button,
+              backgroundColor: '#193340'
+            }}>
+            <Text
+              style={{
+                fontSize: 17,
+                fontWeight: '500',
+                textAlign: 'center',
+                color: '#fff'
+              }}>
+              Finish Activity
+            </Text>
+          </TouchableOpacity>
+        </View>
       </KeyboardAwareScrollView>
     </SafeAreaView>
   )


### PR DESCRIPTION
### [Jira Ticket](https://seven-me.atlassian.net/browse/IS-639)
### [Snack](https://snack.expo.dev/@git/github.com/sevenmeinc/vision@IS-639-SuHa-PostAvtivity-Prompt)

- Updated `content` for one post activity prompt (previously had two).
- Finish Activity Button is now visible but disabled until the client completes all Post Activity prompts.
- Save button is disabled when response is empty or when responses are completed.
- Responses persisted to state
- When responses are done, do not clear input